### PR TITLE
Add alternative to AAPL,ig-platform-id

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ iMac18,3|For High Sierra and older.
 	- AAPL,ig-platform-id
 		- 07009B3E - Replace AAAAAAAA. Used when the Desktop iGPU is used to drive a display.
 		- 00009B3E - Replace AAAAAAAA. Alternative to `07009B3E` if it doesn't work.
+		- 0x3E9B0007 - Replace AAAAAAAA. Alternative to `07009B3E` if it doesn't work.
 		- 0300913E - Replace AAAAAAAA. Used when the Desktop iGPU is only used for computing tasks and doesn't drive a display.
+		
 	- framebuffer-patch-enabl - Uncomment if no BIOS options for iGPU memory.
 	- framebuffer-stolenmem - Uncomment if no BIOS options for iGPU memory.
 


### PR DESCRIPTION
07009B3E and 00009B3E crash in some cases.
Added alternative based on Matheus Sousa's comment and duly tested.

Tested on motherboard H310M (cpu: i3 8100)